### PR TITLE
Fixed some problems with tag lib generation

### DIFF
--- a/jellydoc-maven-plugin/src/main/java/org/jvnet/maven/jellydoc/TagXMLDoclet.java
+++ b/jellydoc-maven-plugin/src/main/java/org/jvnet/maven/jellydoc/TagXMLDoclet.java
@@ -133,7 +133,7 @@ public class TagXMLDoclet extends Doclet {
 
         // generate tags
         for (ClassDoc c : classArray) {
-            if (isTag(c)) {
+            if (isTag(c) && !c.isAbstract()) {
                 tagXML(c,library.tag());
             }
         }
@@ -174,10 +174,6 @@ public class TagXMLDoclet extends Doclet {
      * Generates doc for a tag
      */
     private void tagXML(ClassDoc classDoc, org.jvnet.maven.jellydoc.Tag tag) throws SAXException {
-        if (classDoc.isAbstract()) {
-            return;
-        }
-
         tag.className(classDoc.name());
         String name = classDoc.name();
         if ( name.endsWith( "Tag" ) ) {


### PR DESCRIPTION
Hi,

I am a member of the Apache Commons team, and currently I try to do some maintenance work on the Apache Commons Jelly component. A prerequisite for getting out a new release is to get the site build working again. The build uses the maven-jellydoc-plugin to generate the documentation for the various standard tag libs shipped with Jelly. Unfortunately, I hit two major problems:

* When the plugin was declared and executed in a Maven project of type pom it failed with a FileNotFoundException for the sources directory. The goal is to define the plugin once in the parent project of the several tag lib projects, so that all tag lib documentation can be generated. I was able to fix this problem by skipping the execution for projects that do not have a source directory.
* For tag libs that contained an abstract tag base class the plugin was throwing a NPE; it generated an empty element in the XML schema document describing the single tags. This has been fixed by doing the check for an abstract class before adding an element to the library.

It would be great if the PR was merged and a new release could be published.
Many thanks!
Oliver