### PR TITLE
Use non-reusable CD workflow

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -31,7 +31,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check interesting categories
-        uses: jenkins-infra/interesting-category-action@v1.2.0
+        uses: jenkins-infra/interesting-category-action@v1.2.1
         id: interesting-categories
         if: steps.verify-ci-status.outputs.result == 'success'
         with:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,15 +1,12 @@
 # Switch to https://raw.githubusercontent.com/jenkinsci/.github/master/workflow-templates/cd.yaml once we support Java 11
 
-name: maven-cd
+name: cd
 on:
-  workflow_call:
-    secrets:
-      MAVEN_USERNAME:
-        required: true
-        description: Maven username used for deploying the plugin jar to Jenkins Artifactory Repository
-      MAVEN_TOKEN:
-        required: true
-        description: Maven token used for deploying the plugin jar to Jenkins Artifactory Repository
+  workflow_dispatch:
+  check_run:
+    types:
+      - completed
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -17,14 +14,14 @@ jobs:
       should_release: ${{ steps.verify-ci-status.outputs.result == 'success' && steps.interesting-categories.outputs.interesting == 'true' }}
     steps:
       - name: Verify CI status
-        uses: jenkins-infra/verify-ci-status-action@v1.2.2
+        uses: jenkins-infra/verify-ci-status-action@v1.2.1
         id: verify-ci-status
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           output_result: true
+
       - name: Release Drafter
-        uses: release-drafter/release-drafter@569eb7ee3a85817ab916c8f8ff03a5bd96c9c83e # v5
-        id: draft
+        uses: release-drafter/release-drafter@v5
         if: steps.verify-ci-status.outputs.result == 'success'
         with:
           name: next
@@ -32,13 +29,14 @@ jobs:
           version: next
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Check interesting categories
-        uses: jenkins-infra/interesting-category-action@v1.2.1
+        uses: jenkins-infra/interesting-category-action@v1.1.0
         id: interesting-categories
         if: steps.verify-ci-status.outputs.result == 'success'
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_DRAFT_BODY: ${{ steps.draft.outputs.body }}
+
   release:
     runs-on: ubuntu-latest
     needs: [validate]
@@ -48,13 +46,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
       - name: Release
-        uses: jenkins-infra/jenkins-maven-cd-action@v1.3.3
+        uses: jenkins-infra/jenkins-maven-cd-action@v1.3.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -14,7 +14,7 @@ jobs:
       should_release: ${{ steps.verify-ci-status.outputs.result == 'success' && steps.interesting-categories.outputs.interesting == 'true' }}
     steps:
       - name: Verify CI status
-        uses: jenkins-infra/verify-ci-status-action@v1.2.1
+        uses: jenkins-infra/verify-ci-status-action@v1.2.2
         id: verify-ci-status
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -31,7 +31,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check interesting categories
-        uses: jenkins-infra/interesting-category-action@v1.1.0
+        uses: jenkins-infra/interesting-category-action@v1.2.0
         id: interesting-categories
         if: steps.verify-ci-status.outputs.result == 'success'
         with:
@@ -46,13 +46,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 8
       - name: Release
-        uses: jenkins-infra/jenkins-maven-cd-action@v1.3.0
+        uses: jenkins-infra/jenkins-maven-cd-action@v1.3.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,15 +1,61 @@
-# Note: additional setup is required, see https://www.jenkins.io/redirect/continuous-delivery-of-plugins
+# Switch to https://raw.githubusercontent.com/jenkinsci/.github/master/workflow-templates/cd.yaml once we support Java 11
 
-name: cd
+name: maven-cd
 on:
-  workflow_dispatch:
-  check_run:
-    types:
-      - completed
-
-jobs:
-  maven-cd:
-    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
+  workflow_call:
     secrets:
-      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-      MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
+      MAVEN_USERNAME:
+        required: true
+        description: Maven username used for deploying the plugin jar to Jenkins Artifactory Repository
+      MAVEN_TOKEN:
+        required: true
+        description: Maven token used for deploying the plugin jar to Jenkins Artifactory Repository
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.verify-ci-status.outputs.result == 'success' && steps.interesting-categories.outputs.interesting == 'true' }}
+    steps:
+      - name: Verify CI status
+        uses: jenkins-infra/verify-ci-status-action@v1.2.2
+        id: verify-ci-status
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          output_result: true
+      - name: Release Drafter
+        uses: release-drafter/release-drafter@569eb7ee3a85817ab916c8f8ff03a5bd96c9c83e # v5
+        id: draft
+        if: steps.verify-ci-status.outputs.result == 'success'
+        with:
+          name: next
+          tag: next
+          version: next
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check interesting categories
+        uses: jenkins-infra/interesting-category-action@v1.2.1
+        id: interesting-categories
+        if: steps.verify-ci-status.outputs.result == 'success'
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_DRAFT_BODY: ${{ steps.draft.outputs.body }}
+  release:
+    runs-on: ubuntu-latest
+    needs: [validate]
+    if: needs.validate.outputs.should_release == 'true'
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 8
+      - name: Release
+        uses: jenkins-infra/jenkins-maven-cd-action@v1.3.3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}


### PR DESCRIPTION
Until we support Java 11, we can use the non-reusable action to target Java 8.