### PR TITLE
Require Java 11 or newer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,6 @@ updates:
       - dependency-name: "jaxen:jaxen"
       # maven core artifacts are provided by the running maven, do not update to prevent consuming something unavailable
       - dependency-name: "org.apache.maven:*"
-      # 1.7 and later require Java 11, which this repository does not yet support
-      - dependency-name: "io.jenkins.tools.incrementals:git-changelist-maven-extension"
-        versions: [">=1.7"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,4 +1,4 @@
-# Switch to https://raw.githubusercontent.com/jenkinsci/.github/master/workflow-templates/cd.yaml once we support Java 11
+# Note: additional setup is required, see https://www.jenkins.io/redirect/continuous-delivery-of-plugins
 
 name: cd
 on:
@@ -7,53 +7,13 @@ on:
     types:
       - completed
 
+permissions:
+  checks: read
+  contents: write
+
 jobs:
-  validate:
-    runs-on: ubuntu-latest
-    outputs:
-      should_release: ${{ steps.verify-ci-status.outputs.result == 'success' && steps.interesting-categories.outputs.interesting == 'true' }}
-    steps:
-      - name: Verify CI status
-        uses: jenkins-infra/verify-ci-status-action@v1.2.2
-        id: verify-ci-status
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          output_result: true
-
-      - name: Release Drafter
-        uses: release-drafter/release-drafter@v5
-        if: steps.verify-ci-status.outputs.result == 'success'
-        with:
-          name: next
-          tag: next
-          version: next
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check interesting categories
-        uses: jenkins-infra/interesting-category-action@v1.2.1
-        id: interesting-categories
-        if: steps.verify-ci-status.outputs.result == 'success'
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  release:
-    runs-on: ubuntu-latest
-    needs: [validate]
-    if: needs.validate.outputs.should_release == 'true'
-    steps:
-      - name: Check out
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Set up JDK 8
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 8
-      - name: Release
-        uses: jenkins-infra/jenkins-maven-cd-action@v1.3.3
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
+  maven-cd:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
+    secrets:
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '11'
           cache: 'maven'
       - name: Setup Pages
         uses: actions/configure-pages@v3

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,6 @@
  * allowing one to test against multiple Jenkins versions.
  */
 buildPlugin(useContainerAgent: true, configurations: [
-  [ platform: 'linux', jdk: '8' ],
-  [ platform: 'windows', jdk: '8' ],
+  [platform: 'linux', jdk: 17],
+  [platform: 'windows', jdk: 11],
 ])

--- a/jellydoc-maven-plugin/pom.xml
+++ b/jellydoc-maven-plugin/pom.xml
@@ -30,34 +30,10 @@
               <rules>
                 <requireUpperBoundDeps>
                   <excludes combine.children="append">
-                    <exclude>org.apache.commons:commons-lang3</exclude>
                     <exclude>org.slf4j:slf4j-api</exclude>
-                    <exclude>xerces:xercesImpl</exclude>
                   </excludes>
                 </requireUpperBoundDeps>
               </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <!--
-        This is necessary to ensure that java.home from the build machine doesn't get expanded in
-        the tools.jar dependency below. When we migrate to Java 11 APIs, this should be deleted.
-      -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>flatten-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>flatten</id>
-            <goals>
-              <goal>flatten</goal>
-            </goals>
-            <phase>process-resources</phase>
-            <configuration>
-              <pomElements>
-                <profiles>keep</profiles>
-              </pomElements>
             </configuration>
           </execution>
         </executions>
@@ -202,25 +178,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <!-- TODO migrate to new APIs described in https://docs.oracle.com/en/java/javase/11/docs/api/jdk.javadoc/jdk/javadoc/doclet/package-summary.html#migration -->
-  <profiles>
-    <profile>
-      <id>jdk-8-and-below</id>
-      <activation>
-        <jdk>(,1.8]</jdk>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>com.sun</groupId>
-          <artifactId>tools</artifactId>
-          <version>1.8.0</version>
-          <scope>system</scope>
-          <systemPath>${java.home}/../lib/tools.jar</systemPath>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 
   <reporting>
     <plugins>

--- a/jellydoc-maven-plugin/src/main/java/org/jvnet/maven/jellydoc/JellydocMojo.java
+++ b/jellydoc-maven-plugin/src/main/java/org/jvnet/maven/jellydoc/JellydocMojo.java
@@ -159,7 +159,7 @@ public class JellydocMojo extends AbstractMojo implements MavenMultiPageReport {
         d.setPath(docletPath);
 
         // debug support
-//        javadoc.createArg().setLine("-J-Xrunjdwp:transport=dt_socket,server=y,address=8000");
+//        javadoc.createArg().setLine("-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:8000");
 
         javadoc.execute();
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,6 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/jellydoc-maven-plugin</gitHubRepo>
-    <!-- TODO Remove when we start requiring Java 11. Note that we don't support Java 11 at all yet. -->
-    <incrementals-plugin.version>1.6</incrementals-plugin.version>
   </properties>
 
   <repositories>
@@ -53,95 +51,9 @@
     </pluginRepository>
   </pluginRepositories>
 
-  <build>
-    <plugins>
-      <!-- TODO Remove when we start requiring Java 11. Note that we don't support Java 11 at all yet. -->
-      <plugin>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>display-info</id>
-            <configuration>
-              <rules>
-                <requireJavaVersion>
-                  <version>[1.8.0,]</version>
-                </requireJavaVersion>
-                <enforceBytecodeVersion>
-                  <maxJdkVersion>1.8</maxJdkVersion>
-                </enforceBytecodeVersion>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-
   <modules>
     <module>jellydoc-maven-plugin</module>
     <module>jellydoc-annotations</module>
     <module>taglib-xml-writer</module>
   </modules>
-
-  <!-- TODO Remove when we start requiring Java 11. Note that we don't support Java 11 at all yet. -->
-  <profiles>
-    <profile>
-      <id>jdk-9-and-above</id>
-      <activation>
-        <jdk>[9,)</jdk>
-      </activation>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <configuration>
-                <release>8</release>
-                <testRelease>8</testRelease>
-              </configuration>
-            </plugin>
-            <plugin>
-              <artifactId>maven-javadoc-plugin</artifactId>
-              <configuration>
-                <release>8</release>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-    <profile>
-      <id>jdk-8-and-below</id>
-      <activation>
-        <jdk>(,1.8]</jdk>
-      </activation>
-      <properties>
-        <spotless-maven-plugin.version>2.29.0</spotless-maven-plugin.version>
-      </properties>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <configuration>
-                <source>1.8</source>
-                <target>1.8</target>
-                <testSource>1.8</testSource>
-                <testTarget>1.8</testTarget>
-                <release combine.self="override" />
-                <testRelease combine.self="override" />
-              </configuration>
-            </plugin>
-            <plugin>
-              <artifactId>maven-javadoc-plugin</artifactId>
-              <configuration>
-                <source>1.8</source>
-                <release combine.self="override" />
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
Fixes #38. Migrates away from the Java 8 Javadoc API to the Java 9+ Javadoc API. I could not find any reference material online; this was all learned as I went.

### Testing done

Ran the Mojo before and after this change against Jelly; verified that the generated taglibs looked right.

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
