### PR TITLE
Update jaxen from 1.2.0 to 2.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      # Ignore 1.2.0-atlassian-2
-      - dependency-name: "jaxen:jaxen"
       # maven core artifacts are provided by the running maven, do not update to prevent consuming something unavailable
       - dependency-name: "org.apache.maven:*"
       # 1.7 and later require Java 11, which this repository does not yet support

--- a/jellydoc-maven-plugin/pom.xml
+++ b/jellydoc-maven-plugin/pom.xml
@@ -131,7 +131,7 @@
     <dependency>
       <groupId>jaxen</groupId>
       <artifactId>jaxen</artifactId>
-      <version>1.2.0</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>nekohtml</groupId>


### PR DESCRIPTION
ref https://github.com/jaxen-xpath/jaxen/releases/tag/v2.0.0

The Java version bump doesn't affect us, additionally I removed the exclusion from dependabot, given 2.0.0 is newer than 1.2.0-atlassian-2 