### PR TITLE
Update nekohtml from 1.9.6.2 to 1.9.22

### DIFF
--- a/jellydoc-maven-plugin/pom.xml
+++ b/jellydoc-maven-plugin/pom.xml
@@ -134,9 +134,9 @@
       <version>1.2.0</version>
     </dependency>
     <dependency>
-      <groupId>nekohtml</groupId>
+      <groupId>net.sourceforge.nekohtml</groupId>
       <artifactId>nekohtml</artifactId>
-      <version>1.9.6.2</version>
+      <version>1.9.22</version>
     </dependency>
     <dependency>
       <groupId>net.java.dev.textile-j</groupId>


### PR DESCRIPTION
With using an incremental build of this PR and an incremental of the stapler maven plugin, generating jelly taglib docs for 2.401.2 creates an unaltered result, matching our production generation.