### PR TITLE
Confirm that spotbugs 4.8.2 adds no new warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,10 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/jellydoc-maven-plugin</gitHubRepo>
+    <!-- TODO: Remove when parent pom is using this version or newer -->
+    <!-- https://github.com/jenkinsci/pom/pull/510 -->
+    <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
+    <spotbugs.omitVisitors>FindReturnRef,ConstructorThrow</spotbugs.omitVisitors>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
 


### PR DESCRIPTION
Draft, not intended to be merged

Prep for

* https://github.com/jenkinsci/pom/pull/510

Part of the checklist in:

* https://github.com/jenkinsci/jenkins/pull/8803

Does not need to be merged because there is no additional suppression required.
