### PR TITLE
Migrate from `maven-artifact-transfer` to direct use of Resolver API

### DIFF
--- a/jellydoc-maven-plugin/pom.xml
+++ b/jellydoc-maven-plugin/pom.xml
@@ -129,15 +129,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-artifact-transfer</artifactId>
-      <version>0.13.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.maven.resolver</groupId>
-          <artifactId>maven-resolver-api</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+      <version>2.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.dom4j</groupId>

--- a/jellydoc-maven-plugin/src/main/java/org/jvnet/maven/jellydoc/JellydocMojo.java
+++ b/jellydoc-maven-plugin/src/main/java/org/jvnet/maven/jellydoc/JellydocMojo.java
@@ -160,7 +160,7 @@ public class JellydocMojo extends AbstractMojo implements MavenMultiPageReport {
 
         Artifact artifact = factory.createArtifact(
                 "io.jenkins.tools.maven", "jellydoc-maven-plugin", pluginVersion, null, "maven-plugin");
-        ArtifactRequest request = new ArtifactRequest(RepositoryUtils.toArtifact(artifact), remoteRepositories, "");
+        ArtifactRequest request = new ArtifactRequest(RepositoryUtils.toArtifact(artifact), remoteRepositories, null);
         Artifact self;
         try {
             self = RepositoryUtils.toArtifact(repositorySystem

--- a/jellydoc-maven-plugin/src/main/java/org/jvnet/maven/jellydoc/JellydocMojo.java
+++ b/jellydoc-maven-plugin/src/main/java/org/jvnet/maven/jellydoc/JellydocMojo.java
@@ -161,15 +161,15 @@ public class JellydocMojo extends AbstractMojo implements MavenMultiPageReport {
         Artifact artifact = factory.createArtifact(
                 "io.jenkins.tools.maven", "jellydoc-maven-plugin", pluginVersion, null, "maven-plugin");
         ArtifactRequest request = new ArtifactRequest(RepositoryUtils.toArtifact(artifact), remoteRepositories, "");
-        Artifact resolved;
+        Artifact self;
         try {
-            resolved = RepositoryUtils.toArtifact(repositorySystem
+            self = RepositoryUtils.toArtifact(repositorySystem
                     .resolveArtifact(buildingRequest.getRepositorySession(), request)
                     .getArtifact());
         } catch (ArtifactResolutionException e) {
             throw new MojoExecutionException("Failed to resolve plugin from within itself", e);
         }
-        docletPath.createPathElement().setLocation(resolved.getFile());
+        docletPath.createPathElement().setLocation(self.getFile());
         d.setPath(docletPath);
 
         // debug support

--- a/jellydoc-maven-plugin/src/main/java/org/jvnet/maven/jellydoc/JellydocMojo.java
+++ b/jellydoc-maven-plugin/src/main/java/org/jvnet/maven/jellydoc/JellydocMojo.java
@@ -27,6 +27,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
+import org.apache.maven.RepositoryUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.doxia.sink.Sink;
@@ -41,12 +42,12 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
+import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.reporting.MavenMultiPageReport;
 import org.apache.maven.reporting.MavenReportException;
-import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
-import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolverException;
 import org.apache.tools.ant.DefaultLogger;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Javadoc;
@@ -59,6 +60,10 @@ import org.dom4j.Node;
 import org.dom4j.io.DocumentSource;
 import org.dom4j.io.SAXReader;
 import org.dom4j.tree.DefaultDocument;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
 
 /**
  * Generates jellydoc XML and other artifacts from there.
@@ -102,7 +107,7 @@ public class JellydocMojo extends AbstractMojo implements MavenMultiPageReport {
      * Used for resolving artifacts
      */
     @Component
-    public ArtifactResolver resolver;
+    public RepositorySystem repositorySystem;
 
     @Component
     public MavenProjectHelper helper;
@@ -148,15 +153,22 @@ public class JellydocMojo extends AbstractMojo implements MavenMultiPageReport {
         setParam(d, "-d", targetDir().getAbsolutePath());
 
         Path docletPath = makePath(p, pluginArtifacts);
+
+        ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
+        List<RemoteRepository> remoteRepositories = RepositoryUtils.toRepos(buildingRequest.getRemoteRepositories());
+
+        Artifact artifact = factory.createArtifact(
+                "io.jenkins.tools.maven", "jellydoc-maven-plugin", pluginVersion, null, "maven-plugin");
+        ArtifactRequest request = new ArtifactRequest(RepositoryUtils.toArtifact(artifact), remoteRepositories, "");
+        Artifact resolved;
         try {
-            Artifact self = factory.createArtifact(
-                    "io.jenkins.tools.maven", "jellydoc-maven-plugin", pluginVersion, null, "maven-plugin");
-            self = resolver.resolveArtifact(session.getProjectBuildingRequest(), self)
-                    .getArtifact();
-            docletPath.createPathElement().setLocation(self.getFile());
-        } catch (ArtifactResolverException e) {
+            resolved = RepositoryUtils.toArtifact(repositorySystem
+                    .resolveArtifact(buildingRequest.getRepositorySession(), request)
+                    .getArtifact());
+        } catch (ArtifactResolutionException e) {
             throw new MojoExecutionException("Failed to resolve plugin from within itself", e);
         }
+        docletPath.createPathElement().setLocation(resolved.getFile());
         d.setPath(docletPath);
 
         // debug support

--- a/jellydoc-maven-plugin/src/main/java/org/jvnet/maven/jellydoc/JellydocMojo.java
+++ b/jellydoc-maven-plugin/src/main/java/org/jvnet/maven/jellydoc/JellydocMojo.java
@@ -155,6 +155,7 @@ public class JellydocMojo extends AbstractMojo implements MavenMultiPageReport {
         Path docletPath = makePath(p, pluginArtifacts);
 
         ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
+        buildingRequest.setRemoteRepositories(project.getRemoteArtifactRepositories());
         List<RemoteRepository> remoteRepositories = RepositoryUtils.toRepos(buildingRequest.getRemoteRepositories());
 
         Artifact artifact = factory.createArtifact(


### PR DESCRIPTION
Fixes #64

### Testing done

I tested the plugin in action by running a simple project that reflects how it works: https://github.com/pyatizbyantsevia/jellydoc-maven-plugin-64
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

### Other

I'm not sure if using RepositoryUtils methods is a good idea. The description of this class contains the following comment:
*Warning: This is an internal utility class that is only public for technical reasons, it is not part of the public API. In particular, this class can be changed or deleted without prior notice.*
