### PR TITLE
[JENKINS-75931] Fix links to anchors

### DIFF
--- a/jellydoc-maven-plugin/src/main/java/org/jvnet/maven/jellydoc/ReferenceRenderer.java
+++ b/jellydoc-maven-plugin/src/main/java/org/jvnet/maven/jellydoc/ReferenceRenderer.java
@@ -107,7 +107,7 @@ public class ReferenceRenderer extends AbstractMavenReportRenderer {
             sink.tableRow();
             sink.tableCell();
             String name = tag.attributeValue("name");
-            sink.rawText("<a href='#" + prefix + ':' + name + "'>" + name + "</a>");
+            sink.rawText("<a href='#" + prefix + ".3A" + name + "'>" + name + "</a>");
             sink.tableCell_();
             docCell(tag);
             sink.tableRow_();


### PR DESCRIPTION
See https://issues.jenkins.io/browse/JENKINS-75931.

### Testing done

```
mvn --show-version --batch-mode -DgenerateProjectInfo=false -DgenerateSitemap=false -pl core -am -e -Djellydoc-maven-plugin.version=999999-SNAPSHOT -Dstapler-maven-plugin.version=999999-SNAPSHOT clean site:site
```

I also ran `mvn clean install -Djellydoc-maven-plugin.version=999999-SNAPSHOT` as it didn't seem to work with just the jellydoc-maven-plugin.version set. No clue how much of that was needed (no idea how site plugin works), but I ended up with a 2.516.1 Jellydoc with working anchors with the above.

Lazy origin branch, please delete on merge.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
