### PR TITLE
Require Java 21 to use the plugin and deploy docs

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
           cache: maven
       - name: Setup Pages
         uses: actions/configure-pages@v6


### PR DESCRIPTION
## Require Java 21 to use the plugin and deploy docs

Java 21 has been required since the merge of pull request:

* https://github.com/jenkinsci/jellydoc-maven-plugin/pull/176

If we don't want to require Java 21, then that pull request needs to be reverted.

Fixes the failing deployments of updated documentation.

@timja and @jtnord, is it OK that we release a new version of this Maven plugin and that the new release requires Java 21?

### Testing done

* Confirmed that the plugin does not compile with Java 17
* Confirmed that the plugin compiles successfully with Java 21

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
