### PR TITLE
Restore Java 17 support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,5 +5,6 @@
  */
 buildPlugin(useContainerAgent: true, configurations: [
   [platform: 'linux', jdk: 25],
+  [platform: 'linux', jdk: 17],
   [platform: 'windows', jdk: 21]
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>2.1328.vfd10e2339a_19</version>
+    <version>1.142</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
## Restore Java 17 support

Restore Java 17 support so that plugins are not required to build with Java 21.  Jenkins 2.555.1 is the first Jenkins LTS to require Java 21 or newer.  Most plugins are still supporting Java 17.

Replaces pull request:

* https://github.com/jenkinsci/jellydoc-maven-plugin/pull/184

The [pull request](https://github.com/jenkinsci/jellydoc-maven-plugin/pull/184) notes that this plugin is used in the stapler-maven-plugin and the stapler-maven-plugin does not yet require Java 21. If a new release of jellydoc-maven-plugin is created that requires Java 21, then stapler-maven-plugin will need to require Java 21. The stapler-maven-plugin is used in the plugin pom and the plugin pom intentionally does not require Java 21 yet.

Intentionally includes Java 17 testing in the Jenkinsfile so that we don't inadvertently lose Java 17 support in the future.  The increased cost of testing Java 17 in the Jenkinsfile is worth it in order to avoid accidental updates that drop Java 17 support.  

This reverts commit fb5804573424bfb8952977276f13b841fd690333.

### Testing done

* Confirmed the master branch fails to compile with Java 17
* Confirmed this change compiles with Java 17 and passes tests

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
